### PR TITLE
fix log print error

### DIFF
--- a/server.go
+++ b/server.go
@@ -326,15 +326,16 @@ func (m *NvidiaDevicePlugin) GenerateExtendedResources() {
 			}
 		}
 
-		if errors.IsNotFound(err) {
-			_, err := m.resourceClient.ResourceV1beta1().ExtendedResources().Create(extendedResource)
-			if err != nil {
-				log.Printf("Create ExtendedResource: %+v", err)
-				continue
-			}
-		}
 		if err != nil {
-			log.Printf("Get ExtendedResource: %+v", err)
+			if errors.IsNotFound(err) {
+				_, err := m.resourceClient.ResourceV1beta1().ExtendedResources().Create(extendedResource)
+				if err != nil {
+					log.Printf("Create ExtendedResource: %+v", err)
+					continue
+				}
+			}  else {
+				log.Printf("Get ExtendedResource: %+v", err)
+			}
 		}
 	}
 }


### PR DESCRIPTION
- fix: if er is not exist, the error should be 'Not found', without the need for print 'GET' error

/cc @pendoragon 